### PR TITLE
Update oath package to support passing look-ahead counts and windows TOTP offsets

### DIFF
--- a/pkg/oath/hotp_test.go
+++ b/pkg/oath/hotp_test.go
@@ -96,7 +96,7 @@ func TestVerifyHOTP(t *testing.T) {
 				Digits: lTest.inpDigits,
 			}
 
-			res, err := otp.VerifyHOTP(0, lTest.inpCode)
+			res, err := otp.VerifyHOTP(DefaultLookAheadHOTP, 0, lTest.inpCode)
 			t.Logf("res, err: %v, %v", res, err)
 			require.Equal(t, lTest.res, res)
 			require.Equal(t, lTest.err, err)

--- a/pkg/oath/oath.go
+++ b/pkg/oath/oath.go
@@ -34,6 +34,7 @@ type OTP struct {
 	Digits      int
 	Key         []byte
 	AccountName string
+	TOTPOffset  int
 }
 
 // Secret returns the key in base32 format without padding.

--- a/pkg/oath/totp.go
+++ b/pkg/oath/totp.go
@@ -7,6 +7,8 @@ import (
 	"time"
 )
 
+const DefaultLookAheadTOTP = 1
+
 // TOTP generates a passcode based on the current time.
 func (o *OTP) TOTP() (string, error) {
 	return o.totp(time.Now())
@@ -17,25 +19,30 @@ func (o *OTP) totp(t time.Time) (string, error) {
 	return o.HOTP(t.UnixNano() / int64(time.Duration(period)*time.Second))
 }
 
-// VerifyTOTP verifies a passcode using look-ahead and look-behind windows based
-// on the current time.
-func (o *OTP) VerifyTOTP(passcode string) error {
-	return o.verifyTOTP(time.Now(), passcode)
+// VerifyTOTP verifies a passcode using look-ahead (and look-behind) window
+// count based on the current time and returns the window offset on success.
+// lookAhead should usually be set to DefaultLookAheadTOTP for non-activation
+// use cases.
+func (o *OTP) VerifyTOTP(lookAhead int, passcode string) (int, error) {
+	return o.verifyTOTP(lookAhead, time.Now(), passcode)
 }
 
-// verifyTOTP verifies a passcode using look-ahead and look-behind windows based
-// on the provided time.
-func (o *OTP) verifyTOTP(t time.Time, passcode string) error {
-	for _, d := range []int{0, -1, 1} {
-		pass, err := o.totp(t.Add(time.Duration(d*period) * time.Second))
+// verifyTOTP verifies a passcode using look-ahead (and look-behind) window
+// count based on the provided time and returns the window offset on success.
+// lookAhead should usually be set to DefaultLookAheadTOTP for non-activation
+// use cases.
+func (o *OTP) verifyTOTP(lookAhead int, t time.Time, passcode string) (int,
+	error) {
+	for i := -lookAhead + o.TOTPOffset; i <= lookAhead+o.TOTPOffset; i++ {
+		pass, err := o.totp(t.Add(time.Duration(i*period) * time.Second))
 		if err != nil {
-			return err
+			return 0, err
 		}
 
 		if hmac.Equal([]byte(pass), []byte(passcode)) {
-			return nil
+			return i, nil
 		}
 	}
 
-	return ErrInvalidPasscode
+	return 0, ErrInvalidPasscode
 }


### PR DESCRIPTION
- Update unit tests.
- All test variations pass.