### PR TITLE
Add passcode expiration to SMS method of activate and verify Identity endpoints

### DIFF
--- a/internal/hermes-api/key/key.go
+++ b/internal/hermes-api/key/key.go
@@ -31,3 +31,9 @@ func Challenge(orgID, appID, identityID string) string {
 	return fmt.Sprintf("api:challenge:org:%s:app:%s:identity:%s", orgID, appID,
 		identityID)
 }
+
+// Expire returns a cache key to support passcode expiration.
+func Expire(orgID, appID, identityID, passcode string) string {
+	return fmt.Sprintf("api:expire:org:%s:app:%s:identity:%s:passcode:%s",
+		orgID, appID, identityID, passcode)
+}

--- a/internal/hermes-api/key/key_test.go
+++ b/internal/hermes-api/key/key_test.go
@@ -125,3 +125,27 @@ func TestChallenge(t *testing.T) {
 		})
 	}
 }
+
+func TestExpire(t *testing.T) {
+	t.Parallel()
+
+	for i := 0; i < 5; i++ {
+		lTest := i
+
+		t.Run(fmt.Sprintf("Can key %v", lTest), func(t *testing.T) {
+			t.Parallel()
+
+			orgID := uuid.NewString()
+			appID := uuid.NewString()
+			identityID := uuid.NewString()
+			passcode := random.String(10)
+
+			key := Expire(orgID, appID, identityID, passcode)
+			t.Logf("key: %v", key)
+
+			require.Equal(t, fmt.Sprintf("api:expire:org:%s:app:%s:identity:"+
+				"%s:passcode:%s", orgID, appID, identityID, passcode), key)
+			require.Equal(t, key, Expire(orgID, appID, identityID, passcode))
+		})
+	}
+}

--- a/internal/hermes-api/service/session.go
+++ b/internal/hermes-api/service/session.go
@@ -136,7 +136,7 @@ func (s *Session) DeleteKey(ctx context.Context,
 		return nil, errPerm(common.Role_ADMIN)
 	}
 
-	// Disable API key before removing record. If an incorrect key ID is given,
+	// Disable API key before removing record. If a faulty key ID is given,
 	// it will be confined to this org.
 	if err := s.cache.Set(ctx, key.Disabled(sess.OrgID, req.Id),
 		""); err != nil {

--- a/internal/hermes-api/test/main_test.go
+++ b/internal/hermes-api/test/main_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ownmfa/hermes/pkg/cache"
 	"github.com/ownmfa/hermes/pkg/crypto"
 	"github.com/ownmfa/hermes/pkg/dao"
+	"github.com/ownmfa/hermes/pkg/dao/identity"
 	"github.com/ownmfa/hermes/pkg/dao/org"
 	"github.com/ownmfa/hermes/pkg/dao/user"
 	"github.com/ownmfa/hermes/pkg/queue"
@@ -30,9 +31,10 @@ const (
 )
 
 var (
-	globalOrgDAO  *org.DAO
-	globalUserDAO *user.DAO
-	globalCache   cache.Cacher
+	globalOrgDAO      *org.DAO
+	globalUserDAO     *user.DAO
+	globalIdentityDAO *identity.DAO
+	globalCache       cache.Cacher
 
 	globalPass string
 	// globalHash is stored globally for test performance under -race.
@@ -89,6 +91,7 @@ func TestMain(m *testing.M) {
 	}
 	globalOrgDAO = org.NewDAO(pg)
 	globalUserDAO = user.NewDAO(pg)
+	globalIdentityDAO = identity.NewDAO(pg, key)
 
 	// Set up cache connection.
 	globalCache, err = cache.NewRedis(cfg.RedisHost + ":6379")

--- a/pkg/dao/identity/method.go
+++ b/pkg/dao/identity/method.go
@@ -5,11 +5,14 @@ import (
 	"crypto/rand"
 
 	"github.com/ownmfa/api/go/api"
+	"github.com/ownmfa/hermes/pkg/consterr"
 	"github.com/ownmfa/hermes/pkg/oath"
 )
 
 const (
 	defaultDigits = 7
+
+	errUnknownMethodOneof consterr.Error = "unknown identity.MethodOneof"
 )
 
 // hashAPIToCrypto maps an api.Hash to a crypto.Hash.
@@ -93,6 +96,8 @@ func methodToOTP(identity *api.Identity) (*oath.OTP, string, bool, error) {
 
 		phone = m.SmsMethod.Phone
 		retSecret = false
+	default:
+		return nil, "", false, errUnknownMethodOneof
 	}
 
 	return otp, phone, retSecret, nil

--- a/pkg/dao/identity/method_test.go
+++ b/pkg/dao/identity/method_test.go
@@ -98,6 +98,10 @@ func TestMethodToOTP(t *testing.T) {
 		}}, &oath.OTP{
 			Algorithm: oath.HOTP, Hash: crypto.SHA512, Digits: defaultDigits,
 		}, phone, false, nil},
+		{
+			&api.Identity{MethodOneof: nil}, nil, "", false,
+			errUnknownMethodOneof,
+		},
 	}
 
 	for _, test := range tests {
@@ -115,8 +119,10 @@ func TestMethodToOTP(t *testing.T) {
 				retSecret, err)
 
 			// Normalize secret.
-			require.Len(t, otp.Key, 32)
-			lTest.resOTP.Key = otp.Key
+			if lTest.resOTP != nil {
+				require.Len(t, otp.Key, 32)
+				lTest.resOTP.Key = otp.Key
+			}
 
 			require.Equal(t, lTest.resOTP, otp)
 			require.Equal(t, lTest.resPhone, phone)


### PR DESCRIPTION
- Update key, service, unit and integration tests.
- All test variations pass.