### PR TITLE
Update notifier to increment HOTP prior to sending

### DIFF
--- a/build/deploy/hermes/docker-compose.yml
+++ b/build/deploy/hermes/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   hermes-api:
-    image: ghcr.io/ownmfa/hermes:19034735
+    image: ghcr.io/ownmfa/hermes:680405c4
     command: hermes-api
     depends_on:
       - hermes-notifier
@@ -17,7 +17,7 @@ services:
       - API_NSQ_PUB_ADDR=nsqd:4150
       - API_SMS_TOKEN=notasecurekey
   hermes-notifier:
-    image: ghcr.io/ownmfa/hermes:19034735
+    image: ghcr.io/ownmfa/hermes:680405c4
     command: hermes-notifier
     environment:
       - NOTIFIER_STATSD_ADDR=dogstatsd:8125

--- a/internal/hermes-notifier/notifier/notify_test.go
+++ b/internal/hermes-notifier/notifier/notify_test.go
@@ -76,9 +76,9 @@ func TestNotifyMessages(t *testing.T) {
 				nil).Times(1)
 
 			cacher := cache.NewMockCacher(ctrl)
-			cacher.EXPECT().GetI(gomock.Any(), key.HOTPCounter(
+			cacher.EXPECT().Incr(gomock.Any(), key.HOTPCounter(
 				lTest.inpNIn.OrgId, lTest.inpNIn.AppId,
-				lTest.inpNIn.IdentityId)).Return(true, int64(5), nil).Times(1)
+				lTest.inpNIn.IdentityId)).Return(int64(5), nil).Times(1)
 			cacher.EXPECT().SetIfNotExistTTL(gomock.Any(), key.Expire(
 				lTest.inpNIn.OrgId, lTest.inpNIn.AppId, lTest.inpNIn.IdentityId,
 				"861821"), 1, lTest.inpExpire).Return(true, nil).Times(1)
@@ -139,8 +139,8 @@ func TestNotifyMessagesError(t *testing.T) {
 		inpIdentity              *api.Identity
 		inpIdentityErr           error
 		inpIdentityTimes         int
-		inpGetIErr               error
-		inpGetITimes             int
+		inpIncrErr               error
+		inpIncrTimes             int
 		inpOTP                   *oath.OTP
 		inpAppErr                error
 		inpAppTimes              int
@@ -160,7 +160,7 @@ func TestNotifyMessagesError(t *testing.T) {
 			&message.NotifierIn{}, identity, errTestProc, 1, nil, 0, nil, nil,
 			0, -1, nil, 0, nil, 0, 0,
 		},
-		// Cacher GetI error.
+		// Cacher Incr error.
 		{
 			&message.NotifierIn{}, identity, nil, 1, errTestProc, 1, nil, nil,
 			0, -1, nil, 0, nil, 0, 0,
@@ -213,8 +213,8 @@ func TestNotifyMessagesError(t *testing.T) {
 				lTest.inpIdentityErr).Times(lTest.inpIdentityTimes)
 
 			cacher := cache.NewMockCacher(ctrl)
-			cacher.EXPECT().GetI(gomock.Any(), gomock.Any()).Return(true,
-				int64(5), lTest.inpGetIErr).Times(lTest.inpGetITimes)
+			cacher.EXPECT().Incr(gomock.Any(), gomock.Any()).Return(int64(5),
+				lTest.inpIncrErr).Times(lTest.inpIncrTimes)
 
 			apper := NewMockapper(ctrl)
 			apper.EXPECT().Read(gomock.Any(), gomock.Any(), gomock.Any()).

--- a/internal/hermes-notifier/test/notifier_test.go
+++ b/internal/hermes-notifier/test/notifier_test.go
@@ -95,7 +95,7 @@ func TestNotifyMessagesError(t *testing.T) {
 		err)
 	require.NoError(t, err)
 
-	passcode, err := otp.HOTP(0)
+	passcode, err := otp.HOTP(1)
 	require.NoError(t, err)
 
 	ok, err := globalCache.SetIfNotExist(ctx, key.Expire(createOrg.Id,

--- a/pkg/cache/cacher.go
+++ b/pkg/cache/cacher.go
@@ -32,6 +32,9 @@ type Cacher interface {
 	// exist. If it is successful, it returns true.
 	SetIfNotExistTTL(ctx context.Context, key string, value interface{},
 		exp time.Duration) (bool, error)
+	// Incr increments an int64 value at key by one. If the key does not exist,
+	// the value is set to 1. The incremented value is returned.
+	Incr(ctx context.Context, key string) (int64, error)
 	// Close closes the Cacher, releasing any open resources.
 	Close() error
 }

--- a/pkg/cache/memory_test.go
+++ b/pkg/cache/memory_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ReneKroon/ttlcache/v2"
 	"github.com/ownmfa/hermes/pkg/test/random"
 	"github.com/stretchr/testify/require"
 )
@@ -14,19 +15,15 @@ import (
 func TestNewMemory(t *testing.T) {
 	t.Parallel()
 
-	mem, err := NewMemory()
-	t.Logf("mem, err: %+v, %v", mem, err)
+	mem := NewMemory()
+	t.Logf("mem: %+v", mem)
 	require.NotNil(t, mem)
-	require.NoError(t, err)
 }
 
 func TestMemorySetGet(t *testing.T) {
 	t.Parallel()
 
-	mem, err := NewMemory()
-	t.Logf("mem, err: %+v, %v", mem, err)
-	require.NoError(t, err)
-
+	mem := NewMemory()
 	key := "testMemorySetGet-" + random.String(10)
 	val := random.String(10)
 
@@ -45,21 +42,27 @@ func TestMemorySetGet(t *testing.T) {
 	require.Empty(t, res)
 	require.NoError(t, err)
 
-	// Test next method.
-	ok, resB, err := mem.GetB(context.Background(), key)
-	t.Logf("ok, resB, err: %v, %x, %v", ok, resB, err)
+	require.NoError(t, mem.Set(context.Background(), key, random.Bytes(10)))
+
+	ok, res, err = mem.Get(context.Background(), key)
+	t.Logf("ok, res, err: %v, %v, %v", ok, res, err)
 	require.False(t, ok)
-	require.Empty(t, resB)
+	require.Empty(t, res)
 	require.Equal(t, errWrongType, err)
+
+	require.NoError(t, mem.Close())
+
+	ok, res, err = mem.Get(context.Background(), key)
+	t.Logf("ok, res, err: %v, %v, %v", ok, res, err)
+	require.False(t, ok)
+	require.Empty(t, res)
+	require.Equal(t, ttlcache.ErrClosed, err)
 }
 
 func TestMemorySetTTLGetB(t *testing.T) {
 	t.Parallel()
 
-	mem, err := NewMemory()
-	t.Logf("mem, err: %+v, %v", mem, err)
-	require.NoError(t, err)
-
+	mem := NewMemory()
 	key := "testMemorySetTTLGetB-" + random.String(10)
 	val := random.Bytes(10)
 
@@ -79,21 +82,27 @@ func TestMemorySetTTLGetB(t *testing.T) {
 	require.Empty(t, res)
 	require.NoError(t, err)
 
-	// Test next method.
-	ok, resI, err := mem.GetI(context.Background(), key)
-	t.Logf("ok, resI, err: %v, %x, %v", ok, resI, err)
+	require.NoError(t, mem.Set(context.Background(), key, random.String(10)))
+
+	ok, res, err = mem.GetB(context.Background(), key)
+	t.Logf("ok, res, err: %v, %x, %v", ok, res, err)
 	require.False(t, ok)
-	require.Empty(t, resI)
+	require.Empty(t, res)
 	require.Equal(t, errWrongType, err)
+
+	require.NoError(t, mem.Close())
+
+	ok, res, err = mem.GetB(context.Background(), key)
+	t.Logf("ok, res, err: %v, %x, %v", ok, res, err)
+	require.False(t, ok)
+	require.Empty(t, res)
+	require.Equal(t, ttlcache.ErrClosed, err)
 }
 
 func TestMemorySetTTLGetBShort(t *testing.T) {
 	t.Parallel()
 
-	mem, err := NewMemory()
-	t.Logf("mem, err: %+v, %v", mem, err)
-	require.NoError(t, err)
-
+	mem := NewMemory()
 	key := "testMemorySetTTLGetBShort-" + random.String(10)
 	val := random.Bytes(10)
 
@@ -111,10 +120,7 @@ func TestMemorySetTTLGetBShort(t *testing.T) {
 func TestMemorySetGetI(t *testing.T) {
 	t.Parallel()
 
-	mem, err := NewMemory()
-	t.Logf("mem, err: %+v, %v", mem, err)
-	require.NoError(t, err)
-
+	mem := NewMemory()
 	key := "testMemorySetGetI-" + random.String(10)
 	val := int64(random.Intn(999))
 
@@ -134,21 +140,27 @@ func TestMemorySetGetI(t *testing.T) {
 	require.Empty(t, res)
 	require.NoError(t, err)
 
-	// Test next method.
-	ok, resS, err := mem.Get(context.Background(), key)
-	t.Logf("ok, resS, err: %v, %v, %v", ok, resS, err)
+	require.NoError(t, mem.Set(context.Background(), key, random.String(10)))
+
+	ok, res, err = mem.GetI(context.Background(), key)
+	t.Logf("ok, res, err: %v, %v, %v", ok, res, err)
 	require.False(t, ok)
-	require.Empty(t, resS)
+	require.Empty(t, res)
 	require.Equal(t, errWrongType, err)
+
+	require.NoError(t, mem.Close())
+
+	ok, res, err = mem.GetI(context.Background(), key)
+	t.Logf("ok, res, err: %v, %v, %v", ok, res, err)
+	require.False(t, ok)
+	require.Empty(t, res)
+	require.Equal(t, ttlcache.ErrClosed, err)
 }
 
 func TestMemorySetIfNotExist(t *testing.T) {
 	t.Parallel()
 
-	mem, err := NewMemory()
-	t.Logf("mem, err: %+v, %v", mem, err)
-	require.NoError(t, err)
-
+	mem := NewMemory()
 	key := "testMemorySetIfNotExist-" + random.String(10)
 
 	ok, err := mem.SetIfNotExist(context.Background(), key, random.Bytes(10))
@@ -165,10 +177,7 @@ func TestMemorySetIfNotExist(t *testing.T) {
 func TestMemorySetIfNotExistTTL(t *testing.T) {
 	t.Parallel()
 
-	mem, err := NewMemory()
-	t.Logf("mem, err: %+v, %v", mem, err)
-	require.NoError(t, err)
-
+	mem := NewMemory()
 	key := "testMemorySetIfNotExistTTL-" + random.String(10)
 
 	ok, err := mem.SetIfNotExistTTL(context.Background(), key, random.Bytes(10),
@@ -187,10 +196,7 @@ func TestMemorySetIfNotExistTTL(t *testing.T) {
 func TestMemorySetIfNotExistTTLShort(t *testing.T) {
 	t.Parallel()
 
-	mem, err := NewMemory()
-	t.Logf("mem, err: %+v, %v", mem, err)
-	require.NoError(t, err)
-
+	mem := NewMemory()
 	key := "testMemorySetIfNotExistTTLShort-" + random.String(10)
 
 	ok, err := mem.SetIfNotExistTTL(context.Background(), key, random.Bytes(10),
@@ -207,12 +213,44 @@ func TestMemorySetIfNotExistTTLShort(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestMemoryIncr(t *testing.T) {
+	t.Parallel()
+
+	mem := NewMemory()
+	key := "testMemoryIncr-" + random.String(10)
+	val := int64(random.Intn(999))
+
+	require.NoError(t, mem.Set(context.Background(), key, val))
+
+	res, err := mem.Incr(context.Background(), key)
+	t.Logf("res, err: %v, %v", res, err)
+	require.Equal(t, val+1, res)
+	require.NoError(t, err)
+
+	res, err = mem.Incr(context.Background(),
+		"testMemoryIncr-"+random.String(10))
+	t.Logf("res, err: %v, %v", res, err)
+	require.Equal(t, int64(1), res)
+	require.NoError(t, err)
+
+	require.NoError(t, mem.Set(context.Background(), key, random.String(10)))
+
+	res, err = mem.Incr(context.Background(), key)
+	t.Logf("res, err: %v, %v", res, err)
+	require.Empty(t, res)
+	require.Equal(t, errWrongType, err)
+
+	require.NoError(t, mem.Close())
+
+	res, err = mem.Incr(context.Background(), key)
+	t.Logf("res, err: %v, %v", res, err)
+	require.Empty(t, res)
+	require.Equal(t, ttlcache.ErrClosed, err)
+}
+
 func TestMemoryClose(t *testing.T) {
 	t.Parallel()
 
-	mem, err := NewMemory()
-	t.Logf("mem, err: %+v, %v", mem, err)
-	require.NoError(t, err)
-
+	mem := NewMemory()
 	require.NoError(t, mem.Close())
 }

--- a/pkg/cache/mock_cacher.go
+++ b/pkg/cache/mock_cacher.go
@@ -97,6 +97,21 @@ func (mr *MockCacherMockRecorder) GetI(ctx, key interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetI", reflect.TypeOf((*MockCacher)(nil).GetI), ctx, key)
 }
 
+// Incr mocks base method.
+func (m *MockCacher) Incr(ctx context.Context, key string) (int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Incr", ctx, key)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Incr indicates an expected call of Incr.
+func (mr *MockCacherMockRecorder) Incr(ctx, key interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Incr", reflect.TypeOf((*MockCacher)(nil).Incr), ctx, key)
+}
+
 // Set mocks base method.
 func (m *MockCacher) Set(ctx context.Context, key string, value interface{}) error {
 	m.ctrl.T.Helper()

--- a/pkg/cache/redis.go
+++ b/pkg/cache/redis.go
@@ -106,6 +106,17 @@ func (r *redisCache) SetIfNotExistTTL(ctx context.Context, key string,
 	return r.client.SetNX(ctx, key, value, exp).Result()
 }
 
+// Incr increments an int64 value at key by one. If the key does not exist, the
+// value is set to 1. The incremented value is returned.
+func (r *redisCache) Incr(ctx context.Context, key string) (int64, error) {
+	i, err := r.client.Incr(ctx, key).Result()
+	if err != nil {
+		return 0, err
+	}
+
+	return i, nil
+}
+
 // Close closes the Cacher, releasing any open resources.
 func (r *redisCache) Close() error {
 	return r.client.Close()

--- a/pkg/cache/redis_test.go
+++ b/pkg/cache/redis_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const testTimeout = 2 * time.Second
+const testTimeout = 5 * time.Second
 
 func TestNewRedis(t *testing.T) {
 	t.Parallel()
@@ -76,6 +76,14 @@ func TestRedisSetGet(t *testing.T) {
 	require.False(t, ok)
 	require.Empty(t, res)
 	require.NoError(t, err)
+
+	require.NoError(t, redis.Close())
+
+	ok, res, err = redis.Get(ctx, key)
+	t.Logf("ok, res, err: %v, %v, %v", ok, res, err)
+	require.False(t, ok)
+	require.Empty(t, res)
+	require.EqualError(t, err, "redis: client is closed")
 }
 
 func TestRedisSetTTLGetB(t *testing.T) {
@@ -106,6 +114,14 @@ func TestRedisSetTTLGetB(t *testing.T) {
 	require.False(t, ok)
 	require.Empty(t, res)
 	require.NoError(t, err)
+
+	require.NoError(t, redis.Close())
+
+	ok, res, err = redis.GetB(ctx, key)
+	t.Logf("ok, res, err: %v, %x, %v", ok, res, err)
+	require.False(t, ok)
+	require.Empty(t, res)
+	require.EqualError(t, err, "redis: client is closed")
 }
 
 func TestRedisSetTTLGetBShort(t *testing.T) {
@@ -161,6 +177,14 @@ func TestRedisSetGetI(t *testing.T) {
 	require.False(t, ok)
 	require.Empty(t, res)
 	require.NoError(t, err)
+
+	require.NoError(t, redis.Close())
+
+	ok, res, err = redis.GetI(ctx, key)
+	t.Logf("ok, res, err: %v, %v, %v", ok, res, err)
+	require.False(t, ok)
+	require.Empty(t, res)
+	require.EqualError(t, err, "redis: client is closed")
 }
 
 func TestRedisSetIfNotExist(t *testing.T) {
@@ -238,6 +262,41 @@ func TestRedisSetIfNotExistTTLShort(t *testing.T) {
 	t.Logf("ok, err: %v, %v", ok, err)
 	require.True(t, ok)
 	require.NoError(t, err)
+}
+
+func TestRedisIncr(t *testing.T) {
+	t.Parallel()
+
+	testConfig := config.New()
+
+	redis, err := NewRedis(testConfig.RedisHost + ":6379")
+	t.Logf("redis, err: %+v, %v", redis, err)
+	require.NoError(t, err)
+
+	key := "testRedisIncr-" + random.String(10)
+	val := int64(random.Intn(999))
+
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+	defer cancel()
+
+	require.NoError(t, redis.Set(ctx, key, val))
+
+	res, err := redis.Incr(ctx, key)
+	t.Logf("res, err: %v, %v", res, err)
+	require.Equal(t, val+1, res)
+	require.NoError(t, err)
+
+	res, err = redis.Incr(ctx, "testRedisIncr-"+random.String(10))
+	t.Logf("res, err: %v, %v", res, err)
+	require.Equal(t, int64(1), res)
+	require.NoError(t, err)
+
+	require.NoError(t, redis.Set(ctx, key, random.String(10)))
+
+	res, err = redis.Incr(ctx, key)
+	t.Logf("res, err: %v, %v", res, err)
+	require.Empty(t, res)
+	require.EqualError(t, err, "ERR value is not an integer or out of range")
 }
 
 func TestRedisClose(t *testing.T) {


### PR DESCRIPTION
- Avoid resending the same passcode when they are unverified, and also invalidate the previous passcode.
- Update `pkg/cache` to support `Incr()`.
- All test variations pass.