### PR TITLE
Update Docker Compose deployment to support TLS with Traefik

### DIFF
--- a/build/deploy/deps/docker-compose.yml
+++ b/build/deploy/deps/docker-compose.yml
@@ -48,15 +48,23 @@ services:
     image: traefik:v2.4
     ports:
       - "80:80"
+      # - "443:443"
       - "50051:50051"
     environment:
       - TRAEFIK_LOG_LEVEL=INFO
       - TRAEFIK_PROVIDERS_DOCKER=true
       - TRAEFIK_PROVIDERS_DOCKER_EXPOSEDBYDEFAULT=false
-      - TRAEFIK_ENTRYPOINTS_HTTP_ADDRESS=:80
+      - TRAEFIK_ENTRYPOINTS_PLAINTEXT_ADDRESS=:80
+      # - TRAEFIK_ENTRYPOINTS_TLS_ADDRESS=:443
       - TRAEFIK_ENTRYPOINTS_GRPC_ADDRESS=:50051
+      # - TRAEFIK_CERTIFICATESRESOLVERS_HERMES-TLS_ACME_TLSCHALLENGE=true
+      # - TRAEFIK_CERTIFICATESRESOLVERS_HERMES-TLS_ACME_EMAIL=info@ownmfa.com
+      # - TRAEFIK_CERTIFICATESRESOLVERS_HERMES-TLS_ACME_STORAGE=/letsencrypt/acme.json
+      # - TRAEFIK_ENTRYPOINTS_PLAINTEXT_HTTP_REDIRECTIONS_ENTRYPOINT_TO=tls
+      # - TRAEFIK_ENTRYPOINTS_PLAINTEXT_HTTP_REDIRECTIONS_ENTRYPOINT_SCHEME=https
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
+      # - ./volume/letsencrypt:/letsencrypt
 networks:
   default:
     name: deps

--- a/build/deploy/hermes/docker-compose.yml
+++ b/build/deploy/hermes/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   hermes-api:
-    image: ghcr.io/ownmfa/hermes:29309f1d
+    image: ghcr.io/ownmfa/hermes:4b788c98
     command: hermes-api
     depends_on:
       - hermes-notifier
@@ -16,17 +16,23 @@ services:
       - API_IDENTITY_KEY=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
       - API_NSQ_PUB_ADDR=nsqd:4150
       - API_SMS_KEY_SECRET=notasecurekey
-      - API_PUSHOVER_APP_KEY=notasecurekey
+      - API_PUSHOVER_API_KEY=notasecurekey
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.hermes-api.rule=Host(`hermes.example.com`)"
-      - "traefik.http.routers.hermes-api.entrypoints=http"
-      - "traefik.http.services.hermes-api.loadbalancer.server.port=8000"
-      - "traefik.tcp.routers.hermes-api.rule=HostSNI(`*`)"
-      - "traefik.tcp.routers.hermes-api.entrypoints=grpc"
-      - "traefik.tcp.services.hermes-api.loadbalancer.server.port=50051"
+      - "traefik.http.routers.hermes-web.rule=Host(`hermes.example.com`)"
+      - "traefik.http.routers.hermes-web.entrypoints=plaintext"
+      # - "traefik.http.routers.hermes-web.entrypoints=tls"
+      - "traefik.http.routers.hermes-web.service=hermes-web"
+      # - "traefik.http.routers.hermes-web.tls.certresolver=hermes-tls"
+      - "traefik.http.services.hermes-web.loadbalancer.server.port=8000"
+      - "traefik.http.routers.hermes-grpc.rule=Host(`hermes.example.com`)"
+      - "traefik.http.routers.hermes-grpc.entrypoints=grpc"
+      - "traefik.http.routers.hermes-grpc.service=hermes-grpc"
+      # - "traefik.http.routers.hermes-grpc.tls.certresolver=hermes-tls"
+      - "traefik.http.services.hermes-grpc.loadbalancer.server.port=50051"
+      - "traefik.http.services.hermes-grpc.loadbalancer.server.scheme=h2c"
   hermes-notifier:
-    image: ghcr.io/ownmfa/hermes:29309f1d
+    image: ghcr.io/ownmfa/hermes:4b788c98
     command: hermes-notifier
     environment:
       - NOTIFIER_STATSD_ADDR=dogstatsd:8125
@@ -36,7 +42,7 @@ services:
       - NOTIFIER_NSQ_PUB_ADDR=nsqd:4150
       - NOTIFIER_NSQ_LOOKUP_ADDRS=nsqlookupd:4161
       - NOTIFIER_SMS_KEY_SECRET=notasecurekey
-      - NOTIFIER_PUSHOVER_APP_KEY=notasecurekey
+      - NOTIFIER_PUSHOVER_API_KEY=notasecurekey
       - NOTIFIER_EMAIL_API_KEY=notasecurekey
 networks:
   default:

--- a/go.mod
+++ b/go.mod
@@ -24,8 +24,8 @@ require (
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a
 	golang.org/x/net v0.0.0-20210525063256-abc453219eb5 // indirect
-	golang.org/x/sys v0.0.0-20210525143221-35b2ab0089ea // indirect
-	google.golang.org/genproto v0.0.0-20210524171403-669157292da3 // indirect
+	golang.org/x/sys v0.0.0-20210601080250-7ecdf8ef093b // indirect
+	google.golang.org/genproto v0.0.0-20210602131652-f16073e35f0c // indirect
 	google.golang.org/grpc v1.38.0
 	google.golang.org/protobuf v1.26.0
 )

--- a/go.sum
+++ b/go.sum
@@ -515,6 +515,7 @@ github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/zenazn/goji v0.9.0/go.mod h1:7S9M489iMyHBNxwZnk9/EHS098H4/F6TATF2mIxtB1Q=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
@@ -588,8 +589,9 @@ golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHl
 golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f/go.mod h1:5qLYkcX4OjUUV8bRuDixDT3tpyyb+LUpUlRWLxfhWrs=
 golang.org/x/lint v0.0.0-20200130185559-910be7a94367/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/lint v0.0.0-20200302205851-738671d3881b/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
-golang.org/x/lint v0.0.0-20201208152925-83fdc39ff7b5 h1:2M3HP5CCK1Si9FQhwnzYhXdG6DXeebvUHFpre8QvbyI=
 golang.org/x/lint v0.0.0-20201208152925-83fdc39ff7b5/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
+golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 h1:VLliZ0d+/avPrXXH+OakdXhpJuEoBZuwh1m2j7U6Iug=
+golang.org/x/lint v0.0.0-20210508222113-6edffad5e616/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU15maQ/Ox0txvL9dWGYEHz965HBQE=
 golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028/go.mod h1:E/iHnbuqvinMTCcRqshq8CkpyQDoeVncDDYHnLhea+o=
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=
@@ -598,6 +600,7 @@ golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzB
 golang.org/x/mod v0.1.1-0.20191107180719-034126e5016b/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -639,6 +642,7 @@ golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb/go.mod h1:sp8m0HH+o8qH0wwXwY
 golang.org/x/net v0.0.0-20210119194325-5f4716e94777/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210316092652-d523dce5a7f4/go.mod h1:RBQZq4jEuRlivfhVLdyRGr576XBO4/greRjx4P4O3yc=
+golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20210510120150-4163338589ed/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210525063256-abc453219eb5 h1:wjuX4b5yYQnEQHzd+CBcrcC6OVR2J1CN6mUy0oSxIPo=
 golang.org/x/net v0.0.0-20210525063256-abc453219eb5/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
@@ -708,10 +712,12 @@ golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210315160823-c6e025ad8005/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210514084401-e8d321eab015/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20210525143221-35b2ab0089ea h1:+WiDlPBBaO+h9vPNZi8uJ3k4BkKQB7Iow3aqwHVA5hI=
-golang.org/x/sys v0.0.0-20210525143221-35b2ab0089ea/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210601080250-7ecdf8ef093b h1:qh4f65QIVFjq9eBURLEYWqaEXmOyqdUyiBSgaXWccWk=
+golang.org/x/sys v0.0.0-20210601080250-7ecdf8ef093b/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -779,8 +785,9 @@ golang.org/x/tools v0.0.0-20200804011535-6c149bb5ef0d/go.mod h1:njjCfa9FT2d7l9Bc
 golang.org/x/tools v0.0.0-20200825202427-b303f430e36d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210112230658-8b4aab62c064/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
-golang.org/x/tools v0.1.0 h1:po9/4sTYwZU9lPhi1tOrb4hCv3qrhiQ77LZfGa2OjwY=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
+golang.org/x/tools v0.1.2 h1:kRBLX7v7Af8W7Gdbbc908OJcdgtK8bOz9Uaj8/F1ACA=
+golang.org/x/tools v0.1.2/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/xerrors v0.0.0-20190410155217-1f06c39b4373/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -845,8 +852,8 @@ google.golang.org/genproto v0.0.0-20200825200019-8632dd797987/go.mod h1:FWY/as6D
 google.golang.org/genproto v0.0.0-20210207032614-bba0dbe2a9ea/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20210426193834-eac7f76ac494/go.mod h1:P3QM42oQyzQSnHPnZ/vqoCdDmzH28fzWByN9asMeM8A=
 google.golang.org/genproto v0.0.0-20210518161634-ec7691c0a37d/go.mod h1:P3QM42oQyzQSnHPnZ/vqoCdDmzH28fzWByN9asMeM8A=
-google.golang.org/genproto v0.0.0-20210524171403-669157292da3 h1:xFyh6GBb+NO1L0xqb978I3sBPQpk6FrKO0jJGRvdj/0=
-google.golang.org/genproto v0.0.0-20210524171403-669157292da3/go.mod h1:P3QM42oQyzQSnHPnZ/vqoCdDmzH28fzWByN9asMeM8A=
+google.golang.org/genproto v0.0.0-20210602131652-f16073e35f0c h1:wtujag7C+4D6KMoulW9YauvK2lgdvCMS260jsqqBXr0=
+google.golang.org/genproto v0.0.0-20210602131652-f16073e35f0c/go.mod h1:UODoCrxHCcBojKKwX1terBiRUaqAsFqJiF615XL43r0=
 google.golang.org/grpc v1.17.0/go.mod h1:6QZJwpn2B+Zp71q/5VxRsJ6NXXVCE5NRUHRo+f3cWCs=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.0/go.mod h1:chYK+tFQF0nDUGJgXMSgLCQk3phJEuONr2DCgLDdAQM=

--- a/internal/hermes-notifier/config/config.go
+++ b/internal/hermes-notifier/config/config.go
@@ -26,7 +26,7 @@ type Config struct {
 	SMSAccountID   string
 	SMSKeySecret   string
 	SMSPhone       string
-	PushoverAppKey string
+	PushoverAPIKey string
 	EmailDomain    string
 	EmailAPIKey    string
 }
@@ -56,7 +56,7 @@ func New() *Config {
 			"AC64c88859fa04d39148ac34c18107f883"),
 		SMSKeySecret:   config.String(pref+"SMS_KEY_SECRET", ""),
 		SMSPhone:       config.String(pref+"SMS_PHONE", "+15122344592"),
-		PushoverAppKey: config.String(pref+"PUSHOVER_APP_KEY", ""),
+		PushoverAPIKey: config.String(pref+"PUSHOVER_API_KEY", ""),
 		EmailDomain:    config.String(pref+"EMAIL_DOMAIN", "mg.ownmfa.com"),
 		EmailAPIKey:    config.String(pref+"EMAIL_API_KEY", ""),
 	}

--- a/internal/hermes-notifier/notifier/notifier.go
+++ b/internal/hermes-notifier/notifier/notifier.go
@@ -72,13 +72,13 @@ func New(cfg *config.Config) (*Notifier, error) {
 
 	// Set up Notifier. Allow a mock for local usage, but warn loudly.
 	var n notify.Notifier
-	if cfg.SMSKeySecret == "" || cfg.PushoverAppKey == "" ||
+	if cfg.SMSKeySecret == "" || cfg.PushoverAPIKey == "" ||
 		cfg.EmailAPIKey == "" {
 		hlog.Error("New notify secrets not found, using notify.NewFake()")
 		n = notify.NewFake()
 	} else {
 		n = notify.New(redis, cfg.SMSKeyID, cfg.SMSAccountID, cfg.SMSKeySecret,
-			cfg.SMSPhone, cfg.PushoverAppKey, cfg.EmailDomain, cfg.EmailAPIKey)
+			cfg.SMSPhone, cfg.PushoverAPIKey, cfg.EmailDomain, cfg.EmailAPIKey)
 	}
 
 	// Build the NSQ connection for consuming.

--- a/tool/hermes-create/main.go
+++ b/tool/hermes-create/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/base64"
 	"flag"
 	"fmt"
@@ -20,6 +21,7 @@ import (
 	"github.com/ownmfa/hermes/pkg/dao/user"
 	"github.com/ownmfa/hermes/pkg/test/random"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/encoding/gzip"
 )
 
@@ -75,20 +77,24 @@ func main() {
 			grpc.WithBlock(),
 			grpc.WithDefaultCallOptions(grpc.UseCompressor(gzip.Name)),
 		}
-		if !*grpcTLS {
+
+		switch *grpcTLS {
+		case false:
 			opts = append(opts, grpc.WithInsecure())
+		case true:
+			opts = append(opts, grpc.WithTransportCredentials(
+				credentials.NewTLS(&tls.Config{MinVersion: tls.VersionTLS12})))
 		}
 
 		conn, err := grpc.Dial(*grpcURI, opts...)
 		checkErr(err)
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-		defer cancel()
-
 		cli := api.NewSessionServiceClient(conn)
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 		resp, err := cli.Login(ctx, &api.LoginRequest{
 			Email: flag.Arg(2), OrgName: flag.Arg(1), Password: flag.Arg(3),
 		})
+		cancel()
 		checkErr(err)
 		checkErr(conn.Close())
 
@@ -113,11 +119,10 @@ func main() {
 			os.Exit(1)
 		}
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-		defer cancel()
-
 		orgDAO := org.NewDAO(pg)
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 		createOrg, err := orgDAO.Create(ctx, &api.Org{Name: flag.Arg(1)})
+		cancel()
 		checkErr(err)
 
 		orgID = createOrg.Id

--- a/vendor/golang.org/x/sys/unix/asm_bsd_386.s
+++ b/vendor/golang.org/x/sys/unix/asm_bsd_386.s
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build (darwin || freebsd || netbsd || openbsd) && gc
-// +build darwin freebsd netbsd openbsd
+//go:build (freebsd || netbsd || openbsd) && gc
+// +build freebsd netbsd openbsd
 // +build gc
 
 #include "textflag.h"

--- a/vendor/golang.org/x/sys/unix/asm_bsd_arm.s
+++ b/vendor/golang.org/x/sys/unix/asm_bsd_arm.s
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build (darwin || freebsd || netbsd || openbsd) && gc
-// +build darwin freebsd netbsd openbsd
+//go:build (freebsd || netbsd || openbsd) && gc
+// +build freebsd netbsd openbsd
 // +build gc
 
 #include "textflag.h"

--- a/vendor/golang.org/x/sys/unix/mkerrors.sh
+++ b/vendor/golang.org/x/sys/unix/mkerrors.sh
@@ -594,7 +594,7 @@ ccflags="$@"
 		$2 == "HID_MAX_DESCRIPTOR_SIZE" ||
 		$2 ~ /^_?HIDIOC/ ||
 		$2 ~ /^BUS_(USB|HIL|BLUETOOTH|VIRTUAL)$/ ||
-		$2 ~ /^MTD_/ ||
+		$2 ~ /^MTD/ ||
 		$2 ~ /^OTP/ ||
 		$2 ~ /^MEM/ ||
 		$2 ~ /^BLK[A-Z]*(GET$|SET$|BUF$|PART$|SIZE)/ {printf("\t%s = C.%s\n", $2, $2)}

--- a/vendor/golang.org/x/sys/unix/zerrors_linux_386.go
+++ b/vendor/golang.org/x/sys/unix/zerrors_linux_386.go
@@ -137,6 +137,7 @@ const (
 	MEMSETBADBLOCK                   = 0x40084d0c
 	MEMUNLOCK                        = 0x40084d06
 	MEMWRITEOOB                      = 0xc00c4d03
+	MTDFILEMODE                      = 0x4d13
 	NFDBITS                          = 0x20
 	NLDLY                            = 0x100
 	NOFLSH                           = 0x80

--- a/vendor/golang.org/x/sys/unix/zerrors_linux_amd64.go
+++ b/vendor/golang.org/x/sys/unix/zerrors_linux_amd64.go
@@ -137,6 +137,7 @@ const (
 	MEMSETBADBLOCK                   = 0x40084d0c
 	MEMUNLOCK                        = 0x40084d06
 	MEMWRITEOOB                      = 0xc0104d03
+	MTDFILEMODE                      = 0x4d13
 	NFDBITS                          = 0x40
 	NLDLY                            = 0x100
 	NOFLSH                           = 0x80

--- a/vendor/golang.org/x/sys/unix/zerrors_linux_arm.go
+++ b/vendor/golang.org/x/sys/unix/zerrors_linux_arm.go
@@ -135,6 +135,7 @@ const (
 	MEMSETBADBLOCK                   = 0x40084d0c
 	MEMUNLOCK                        = 0x40084d06
 	MEMWRITEOOB                      = 0xc00c4d03
+	MTDFILEMODE                      = 0x4d13
 	NFDBITS                          = 0x20
 	NLDLY                            = 0x100
 	NOFLSH                           = 0x80

--- a/vendor/golang.org/x/sys/unix/zerrors_linux_arm64.go
+++ b/vendor/golang.org/x/sys/unix/zerrors_linux_arm64.go
@@ -138,6 +138,7 @@ const (
 	MEMSETBADBLOCK                   = 0x40084d0c
 	MEMUNLOCK                        = 0x40084d06
 	MEMWRITEOOB                      = 0xc0104d03
+	MTDFILEMODE                      = 0x4d13
 	NFDBITS                          = 0x40
 	NLDLY                            = 0x100
 	NOFLSH                           = 0x80

--- a/vendor/golang.org/x/sys/unix/zerrors_linux_mips.go
+++ b/vendor/golang.org/x/sys/unix/zerrors_linux_mips.go
@@ -135,6 +135,7 @@ const (
 	MEMSETBADBLOCK                   = 0x80084d0c
 	MEMUNLOCK                        = 0x80084d06
 	MEMWRITEOOB                      = 0xc00c4d03
+	MTDFILEMODE                      = 0x20004d13
 	NFDBITS                          = 0x20
 	NLDLY                            = 0x100
 	NOFLSH                           = 0x80

--- a/vendor/golang.org/x/sys/unix/zerrors_linux_mips64.go
+++ b/vendor/golang.org/x/sys/unix/zerrors_linux_mips64.go
@@ -135,6 +135,7 @@ const (
 	MEMSETBADBLOCK                   = 0x80084d0c
 	MEMUNLOCK                        = 0x80084d06
 	MEMWRITEOOB                      = 0xc0104d03
+	MTDFILEMODE                      = 0x20004d13
 	NFDBITS                          = 0x40
 	NLDLY                            = 0x100
 	NOFLSH                           = 0x80

--- a/vendor/golang.org/x/sys/unix/zerrors_linux_mips64le.go
+++ b/vendor/golang.org/x/sys/unix/zerrors_linux_mips64le.go
@@ -135,6 +135,7 @@ const (
 	MEMSETBADBLOCK                   = 0x80084d0c
 	MEMUNLOCK                        = 0x80084d06
 	MEMWRITEOOB                      = 0xc0104d03
+	MTDFILEMODE                      = 0x20004d13
 	NFDBITS                          = 0x40
 	NLDLY                            = 0x100
 	NOFLSH                           = 0x80

--- a/vendor/golang.org/x/sys/unix/zerrors_linux_mipsle.go
+++ b/vendor/golang.org/x/sys/unix/zerrors_linux_mipsle.go
@@ -135,6 +135,7 @@ const (
 	MEMSETBADBLOCK                   = 0x80084d0c
 	MEMUNLOCK                        = 0x80084d06
 	MEMWRITEOOB                      = 0xc00c4d03
+	MTDFILEMODE                      = 0x20004d13
 	NFDBITS                          = 0x20
 	NLDLY                            = 0x100
 	NOFLSH                           = 0x80

--- a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc.go
+++ b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc.go
@@ -135,6 +135,7 @@ const (
 	MEMSETBADBLOCK                   = 0x80084d0c
 	MEMUNLOCK                        = 0x80084d06
 	MEMWRITEOOB                      = 0xc00c4d03
+	MTDFILEMODE                      = 0x20004d13
 	NFDBITS                          = 0x20
 	NL2                              = 0x200
 	NL3                              = 0x300

--- a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64.go
+++ b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64.go
@@ -135,6 +135,7 @@ const (
 	MEMSETBADBLOCK                   = 0x80084d0c
 	MEMUNLOCK                        = 0x80084d06
 	MEMWRITEOOB                      = 0xc0104d03
+	MTDFILEMODE                      = 0x20004d13
 	NFDBITS                          = 0x40
 	NL2                              = 0x200
 	NL3                              = 0x300

--- a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64le.go
+++ b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64le.go
@@ -135,6 +135,7 @@ const (
 	MEMSETBADBLOCK                   = 0x80084d0c
 	MEMUNLOCK                        = 0x80084d06
 	MEMWRITEOOB                      = 0xc0104d03
+	MTDFILEMODE                      = 0x20004d13
 	NFDBITS                          = 0x40
 	NL2                              = 0x200
 	NL3                              = 0x300

--- a/vendor/golang.org/x/sys/unix/zerrors_linux_riscv64.go
+++ b/vendor/golang.org/x/sys/unix/zerrors_linux_riscv64.go
@@ -135,6 +135,7 @@ const (
 	MEMSETBADBLOCK                   = 0x40084d0c
 	MEMUNLOCK                        = 0x40084d06
 	MEMWRITEOOB                      = 0xc0104d03
+	MTDFILEMODE                      = 0x4d13
 	NFDBITS                          = 0x40
 	NLDLY                            = 0x100
 	NOFLSH                           = 0x80

--- a/vendor/golang.org/x/sys/unix/zerrors_linux_s390x.go
+++ b/vendor/golang.org/x/sys/unix/zerrors_linux_s390x.go
@@ -135,6 +135,7 @@ const (
 	MEMSETBADBLOCK                   = 0x40084d0c
 	MEMUNLOCK                        = 0x40084d06
 	MEMWRITEOOB                      = 0xc0104d03
+	MTDFILEMODE                      = 0x4d13
 	NFDBITS                          = 0x40
 	NLDLY                            = 0x100
 	NOFLSH                           = 0x80

--- a/vendor/golang.org/x/sys/unix/zerrors_linux_sparc64.go
+++ b/vendor/golang.org/x/sys/unix/zerrors_linux_sparc64.go
@@ -140,6 +140,7 @@ const (
 	MEMSETBADBLOCK                   = 0x80084d0c
 	MEMUNLOCK                        = 0x80084d06
 	MEMWRITEOOB                      = 0xc0104d03
+	MTDFILEMODE                      = 0x20004d13
 	NFDBITS                          = 0x40
 	NLDLY                            = 0x100
 	NOFLSH                           = 0x80

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -135,7 +135,7 @@ golang.org/x/net/internal/timeseries
 golang.org/x/net/trace
 # golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 golang.org/x/sync/singleflight
-# golang.org/x/sys v0.0.0-20210525143221-35b2ab0089ea
+# golang.org/x/sys v0.0.0-20210601080250-7ecdf8ef093b
 ## explicit
 golang.org/x/sys/internal/unsafeheader
 golang.org/x/sys/unix
@@ -153,7 +153,7 @@ golang.org/x/text/transform
 golang.org/x/text/unicode/bidi
 golang.org/x/text/unicode/norm
 golang.org/x/text/width
-# google.golang.org/genproto v0.0.0-20210524171403-669157292da3
+# google.golang.org/genproto v0.0.0-20210602131652-f16073e35f0c
 ## explicit
 google.golang.org/genproto/googleapis/api/annotations
 google.golang.org/genproto/googleapis/api/httpbody


### PR DESCRIPTION
- Update `hermes-create login` to support CA-based TLS.
- Sync `vendor/` for updated dependencies.
- All test variations pass.