### PR TITLE
Add read caching to Org DAO

### DIFF
--- a/internal/hermes-api/test/main_test.go
+++ b/internal/hermes-api/test/main_test.go
@@ -91,7 +91,7 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		log.Fatalf("TestMain dao.NewPgDB: %v", err)
 	}
-	globalOrgDAO = org.NewDAO(pg)
+	globalOrgDAO = org.NewDAO(pg, nil, 0)
 	globalUserDAO = user.NewDAO(pg)
 	globalIdentDAO = identity.NewDAO(pg, key)
 	globalEvDAO = event.NewDAO(pg)

--- a/internal/hermes-notifier/test/main_test.go
+++ b/internal/hermes-notifier/test/main_test.go
@@ -78,7 +78,7 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		log.Fatalf("TestMain dao.NewPgDB: %v", err)
 	}
-	globalOrgDAO = org.NewDAO(pg)
+	globalOrgDAO = org.NewDAO(pg, nil, 0)
 	globalAppDAO = app.NewDAO(pg)
 	globalIdentDAO = identity.NewDAO(pg, key)
 	globalEvDAO = event.NewDAO(pg)

--- a/pkg/cache/cacher.go
+++ b/pkg/cache/cacher.go
@@ -35,6 +35,8 @@ type Cacher interface {
 	// Incr increments an int64 value at key by one. If the key does not exist,
 	// the value is set to 1. The incremented value is returned.
 	Incr(ctx context.Context, key string) (int64, error)
+	// Del removes the specified key. A key is ignored if it does not exist.
+	Del(ctx context.Context, key string) error
 	// Close closes the Cacher, releasing any open resources.
 	Close() error
 }

--- a/pkg/cache/memory.go
+++ b/pkg/cache/memory.go
@@ -169,6 +169,19 @@ func (m *memoryCache) Incr(ctx context.Context, key string) (int64, error) {
 	return i, nil
 }
 
+// Del removes the specified key. A key is ignored if it does not exist.
+func (m *memoryCache) Del(ctx context.Context, key string) error {
+	m.cacheMu.Lock()
+	defer m.cacheMu.Unlock()
+
+	if err := m.cache.Remove(key); err != nil &&
+		!errors.Is(err, ttlcache.ErrNotFound) {
+		return err
+	}
+
+	return nil
+}
+
 // Close closes the Cacher, releasing any open resources.
 func (m *memoryCache) Close() error {
 	return m.cache.Close()

--- a/pkg/cache/memory_test.go
+++ b/pkg/cache/memory_test.go
@@ -248,6 +248,38 @@ func TestMemoryIncr(t *testing.T) {
 	require.Equal(t, ttlcache.ErrClosed, err)
 }
 
+func TestMemoryDel(t *testing.T) {
+	t.Parallel()
+
+	mem := NewMemory()
+	key := "testMemoryDel-" + random.String(10)
+	val := random.String(10)
+
+	require.NoError(t, mem.Set(context.Background(), key, val))
+
+	ok, res, err := mem.Get(context.Background(), key)
+	t.Logf("ok, res, err: %v, %v, %v", ok, res, err)
+	require.True(t, ok)
+	require.Equal(t, val, res)
+	require.NoError(t, err)
+
+	err = mem.Del(context.Background(), key)
+	t.Logf("err: %v", err)
+	require.NoError(t, err)
+
+	ok, res, err = mem.Get(context.Background(), key)
+	t.Logf("ok, res, err: %v, %v, %v", ok, res, err)
+	require.False(t, ok)
+	require.Empty(t, res)
+	require.NoError(t, err)
+
+	require.NoError(t, mem.Close())
+
+	err = mem.Del(context.Background(), key)
+	t.Logf("err: %v", err)
+	require.Equal(t, ttlcache.ErrClosed, err)
+}
+
 func TestMemoryClose(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/cache/mock_cacher.go
+++ b/pkg/cache/mock_cacher.go
@@ -49,6 +49,20 @@ func (mr *MockCacherMockRecorder) Close() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockCacher)(nil).Close))
 }
 
+// Del mocks base method.
+func (m *MockCacher) Del(ctx context.Context, key string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Del", ctx, key)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Del indicates an expected call of Del.
+func (mr *MockCacherMockRecorder) Del(ctx, key interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Del", reflect.TypeOf((*MockCacher)(nil).Del), ctx, key)
+}
+
 // Get mocks base method.
 func (m *MockCacher) Get(ctx context.Context, key string) (bool, string, error) {
 	m.ctrl.T.Helper()

--- a/pkg/cache/redis.go
+++ b/pkg/cache/redis.go
@@ -117,6 +117,11 @@ func (r *redisCache) Incr(ctx context.Context, key string) (int64, error) {
 	return i, nil
 }
 
+// Del removes the specified key. A key is ignored if it does not exist.
+func (r *redisCache) Del(ctx context.Context, key string) error {
+	return r.client.Del(ctx, key).Err()
+}
+
 // Close closes the Cacher, releasing any open resources.
 func (r *redisCache) Close() error {
 	return r.client.Close()

--- a/pkg/cache/redis_test.go
+++ b/pkg/cache/redis_test.go
@@ -299,6 +299,40 @@ func TestRedisIncr(t *testing.T) {
 	require.EqualError(t, err, "ERR value is not an integer or out of range")
 }
 
+func TestRedisDel(t *testing.T) {
+	t.Parallel()
+
+	testConfig := config.New()
+
+	redis, err := NewRedis(testConfig.RedisHost + ":6379")
+	t.Logf("redis, err: %+v, %v", redis, err)
+	require.NoError(t, err)
+
+	key := "testRedisDel-" + random.String(10)
+	val := random.String(10)
+
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+	defer cancel()
+
+	require.NoError(t, redis.Set(ctx, key, val))
+
+	ok, res, err := redis.Get(ctx, key)
+	t.Logf("ok, res, err: %v, %v, %v", ok, res, err)
+	require.True(t, ok)
+	require.Equal(t, val, res)
+	require.NoError(t, err)
+
+	err = redis.Del(ctx, key)
+	t.Logf("err: %v", err)
+	require.NoError(t, err)
+
+	ok, res, err = redis.Get(ctx, key)
+	t.Logf("ok, res, err: %v, %v, %v", ok, res, err)
+	require.False(t, ok)
+	require.Empty(t, res)
+	require.NoError(t, err)
+}
+
 func TestRedisClose(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/dao/app/main_test.go
+++ b/pkg/dao/app/main_test.go
@@ -26,7 +26,7 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		log.Fatalf("TestMain dao.NewPgDB: %v", err)
 	}
-	globalOrgDAO = org.NewDAO(pg)
+	globalOrgDAO = org.NewDAO(pg, nil, 0)
 	globalAppDAO = NewDAO(pg)
 
 	os.Exit(m.Run())

--- a/pkg/dao/event/main_test.go
+++ b/pkg/dao/event/main_test.go
@@ -26,7 +26,7 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		log.Fatalf("TestMain dao.NewPgDB: %v", err)
 	}
-	globalOrgDAO = org.NewDAO(pg)
+	globalOrgDAO = org.NewDAO(pg, nil, 0)
 	globalEvDAO = NewDAO(pg)
 
 	os.Exit(m.Run())

--- a/pkg/dao/identity/main_test.go
+++ b/pkg/dao/identity/main_test.go
@@ -34,7 +34,7 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		log.Fatalf("TestMain dao.NewPgDB: %v", err)
 	}
-	globalOrgDAO = org.NewDAO(pg)
+	globalOrgDAO = org.NewDAO(pg, nil, 0)
 	globalAppDAO = app.NewDAO(pg)
 	globalIdentDAO = NewDAO(pg, key)
 

--- a/pkg/dao/key/main_test.go
+++ b/pkg/dao/key/main_test.go
@@ -26,7 +26,7 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		log.Fatalf("TestMain dao.NewPgDB: %v", err)
 	}
-	globalOrgDAO = org.NewDAO(pg)
+	globalOrgDAO = org.NewDAO(pg, nil, 0)
 	globalKeyDAO = NewDAO(pg)
 
 	os.Exit(m.Run())

--- a/pkg/dao/org/dao.go
+++ b/pkg/dao/org/dao.go
@@ -4,16 +4,24 @@ package org
 
 import (
 	"database/sql"
+	"time"
+
+	"github.com/ownmfa/hermes/pkg/cache"
 )
 
 // DAO contains functions to query and modify organizations in the database.
 type DAO struct {
-	pg *sql.DB
+	pg    *sql.DB
+	cache cache.Cacher
+	exp   time.Duration
 }
 
-// NewDAO instantiates and returns a new DAO.
-func NewDAO(pg *sql.DB) *DAO {
+// NewDAO instantiates and returns a new DAO with organization read caching.
+// Cache can be set to nil to disable caching.
+func NewDAO(pg *sql.DB, cache cache.Cacher, exp time.Duration) *DAO {
 	return &DAO{
-		pg: pg,
+		pg:    pg,
+		cache: cache,
+		exp:   exp,
 	}
 }

--- a/pkg/dao/org/key.go
+++ b/pkg/dao/org/key.go
@@ -1,0 +1,8 @@
+package org
+
+import "fmt"
+
+// orgKey returns a cache key to support organization keys.
+func orgKey(orgID string) string {
+	return fmt.Sprintf("dao:org:%s", orgID)
+}

--- a/pkg/dao/org/key_test.go
+++ b/pkg/dao/org/key_test.go
@@ -1,0 +1,31 @@
+// +build !integration
+
+package org
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOrgKey(t *testing.T) {
+	t.Parallel()
+
+	for i := 0; i < 5; i++ {
+		lTest := i
+
+		t.Run(fmt.Sprintf("Can key %v", lTest), func(t *testing.T) {
+			t.Parallel()
+
+			orgID := uuid.NewString()
+
+			key := orgKey(orgID)
+			t.Logf("key: %v", key)
+
+			require.Equal(t, fmt.Sprintf("dao:org:%s", orgID), key)
+			require.Equal(t, key, orgKey(orgID))
+		})
+	}
+}

--- a/pkg/dao/org/main_test.go
+++ b/pkg/dao/org/main_test.go
@@ -6,12 +6,17 @@ import (
 	"log"
 	"os"
 	"testing"
+	"time"
 
+	"github.com/ownmfa/hermes/pkg/cache"
 	"github.com/ownmfa/hermes/pkg/dao"
 	"github.com/ownmfa/hermes/pkg/test/config"
 )
 
-var globalOrgDAO *DAO
+var (
+	globalOrgDAO      *DAO
+	globalOrgDAOCache *DAO
+)
 
 func TestMain(m *testing.M) {
 	// Set up Config.
@@ -22,7 +27,8 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		log.Fatalf("TestMain dao.NewPgDB: %v", err)
 	}
-	globalOrgDAO = NewDAO(pg)
+	globalOrgDAO = NewDAO(pg, nil, 0)
+	globalOrgDAOCache = NewDAO(pg, cache.NewMemory(), time.Minute)
 
 	os.Exit(m.Run())
 }

--- a/pkg/dao/user/main_test.go
+++ b/pkg/dao/user/main_test.go
@@ -26,7 +26,7 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		log.Fatalf("TestMain dao.NewPgDB: %v", err)
 	}
-	globalOrgDAO = org.NewDAO(pg)
+	globalOrgDAO = org.NewDAO(pg, nil, 0)
 	globalUserDAO = NewDAO(pg)
 
 	os.Exit(m.Run())

--- a/tool/hermes-create/main.go
+++ b/tool/hermes-create/main.go
@@ -119,9 +119,15 @@ func main() {
 			os.Exit(1)
 		}
 
-		orgDAO := org.NewDAO(pg)
+		o := &api.Org{
+			Name:   flag.Arg(1),
+			Status: api.Status_ACTIVE,
+			Plan:   api.Plan_STARTER,
+		}
+
+		orgDAO := org.NewDAO(pg, nil, 0)
 		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-		createOrg, err := orgDAO.Create(ctx, &api.Org{Name: flag.Arg(1)})
+		createOrg, err := orgDAO.Create(ctx, o)
 		cancel()
 		checkErr(err)
 


### PR DESCRIPTION
- Update `pkg/cache` to support `Del()`.
- Update DAO, integration tests, and callers for `NewDAO()`.
- Sync `vendor/` for updated dependencies.
- All test variations pass.