### PR TITLE
Update grpc-gateway to v2.13.0

### DIFF
--- a/build/deploy/hermes-deps/docker-compose.yml
+++ b/build/deploy/hermes-deps/docker-compose.yml
@@ -55,7 +55,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
 
   traefik:
-    image: traefik:v2.8
+    image: traefik:v2.9
     ports:
       - "80:80"
       # - "443:443"

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/google/uuid v1.3.0
 	github.com/gregdel/pushover v1.1.0
-	github.com/grpc-ecosystem/grpc-gateway/v2 v2.12.0
+	github.com/grpc-ecosystem/grpc-gateway/v2 v2.13.0
 	github.com/jackc/pgconn v1.13.0
 	github.com/jackc/pgx/v4 v4.17.2
 	github.com/mennanov/fmutils v0.2.0
@@ -18,8 +18,8 @@ require (
 	github.com/rs/zerolog v1.28.0
 	github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e
 	github.com/smira/go-statsd v1.3.2
-	github.com/stretchr/testify v1.8.0
-	golang.org/x/crypto v0.0.0-20221012134737-56aed061732a
+	github.com/stretchr/testify v1.8.1
+	golang.org/x/crypto v0.1.0
 	google.golang.org/grpc v1.50.1
 	google.golang.org/protobuf v1.28.1
 )
@@ -40,10 +40,10 @@ require (
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.16 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	golang.org/x/net v0.0.0-20221017152216-f25eb7ecb193 // indirect
+	golang.org/x/net v0.1.0 // indirect
 	golang.org/x/sync v0.1.0 // indirect
 	golang.org/x/sys v0.1.0 // indirect
 	golang.org/x/text v0.4.0 // indirect
-	google.golang.org/genproto v0.0.0-20221018160656-63c7b68cfc55 // indirect
+	google.golang.org/genproto v0.0.0-20221027153422-115e99e71e1c // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -154,8 +154,8 @@ github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5m
 github.com/googleapis/google-cloud-go-testing v0.0.0-20200911160855-bcd43fbb19e8/go.mod h1:dvDLG8qkwmyD9a/MJJN3XJcT3xFxOKAvTZGvuZmac9g=
 github.com/gregdel/pushover v1.1.0 h1:dwHyvrcpZCOS9V1fAnKPaGRRI5OC55cVaKhMybqNsKQ=
 github.com/gregdel/pushover v1.1.0/go.mod h1:EcaO66Nn1StkpEm1iKtBTV3d2A16SoMsVER1PthX7to=
-github.com/grpc-ecosystem/grpc-gateway/v2 v2.12.0 h1:kr3j8iIMR4ywO/O0rvksXaJvauGGCMg2zAZIiNZ9uIQ=
-github.com/grpc-ecosystem/grpc-gateway/v2 v2.12.0/go.mod h1:ummNFgdgLhhX7aIiy35vVmQNS0rWXknfPE0qe6fmFXg=
+github.com/grpc-ecosystem/grpc-gateway/v2 v2.13.0 h1:fi9bGIUJOGzzrHBbP8NWbTfNC5fKO6X7kFw40TOqGB8=
+github.com/grpc-ecosystem/grpc-gateway/v2 v2.13.0/go.mod h1:uY3Aurq+SxwQCpdX91xZ9CgxIMT1EsYtcidljXufYIY=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
@@ -277,6 +277,7 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
@@ -284,8 +285,9 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
+github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -325,8 +327,8 @@ golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97/go.mod h1:GvvjBRRGRdwPK5y
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20211108221036-ceb1ce70b4fa/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
-golang.org/x/crypto v0.0.0-20221012134737-56aed061732a h1:NmSIgad6KjE6VvHciPZuNRTKxGhlPfD6OA87W/PLkqg=
-golang.org/x/crypto v0.0.0-20221012134737-56aed061732a/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
+golang.org/x/crypto v0.1.0 h1:MDRAIl0xIo9Io2xV565hzXHw3zVseKrJKodhohM5CjU=
+golang.org/x/crypto v0.1.0/go.mod h1:RecgLatLF4+eUMCP1PoPZQb+cVrJcOPbHkTkbkB9sbw=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
@@ -400,8 +402,8 @@ golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96b
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.0.0-20220907135653-1e95f45603a7/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
-golang.org/x/net v0.0.0-20221017152216-f25eb7ecb193 h1:3Moaxt4TfzNcQH6DWvlYKraN1ozhBXQHcgvXjRGeim0=
-golang.org/x/net v0.0.0-20221017152216-f25eb7ecb193/go.mod h1:RpDiru2p0u2F0lLpEoqnP2+7xs0ifAuOcJ442g6GU2s=
+golang.org/x/net v0.1.0 h1:hZ/3BUoy5aId7sCpA/Tc5lt8DkFgdVS2onTpJsZ/fl0=
+golang.org/x/net v0.1.0/go.mod h1:Cx3nUiGt4eDBEyega/BKRp+/AlGL8hYe7U9odMt2Cco=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -618,8 +620,8 @@ google.golang.org/genproto v0.0.0-20201210142538-e3217bee35cc/go.mod h1:FWY/as6D
 google.golang.org/genproto v0.0.0-20201214200347-8c77b98c765d/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20210108203827-ffc7fda8c3d7/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20210226172003-ab064af71705/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
-google.golang.org/genproto v0.0.0-20221018160656-63c7b68cfc55 h1:U1u4KB2kx6KR/aJDjQ97hZ15wQs8ZPvDcGcRynBhkvg=
-google.golang.org/genproto v0.0.0-20221018160656-63c7b68cfc55/go.mod h1:45EK0dUbEZ2NHjCeAd2LXmyjAgGUGrpGROgjhC3ADck=
+google.golang.org/genproto v0.0.0-20221027153422-115e99e71e1c h1:QgY/XxIAIeccR+Ca/rDdKubLIU9rcJ3xfy1DC/Wd2Oo=
+google.golang.org/genproto v0.0.0-20221027153422-115e99e71e1c/go.mod h1:CGI5F/G+E5bKwmfYo09AXuVN4dD894kIKUFmVbP2/Fo=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
 google.golang.org/grpc v1.21.1/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=

--- a/internal/hermes-api/service/event.go
+++ b/internal/hermes-api/service/event.go
@@ -47,12 +47,12 @@ func (e *Event) ListEvents(ctx context.Context, req *api.ListEventsRequest) (
 
 	end := time.Now().UTC()
 	if req.EndTime != nil {
-		end = req.EndTime.AsTime().UTC()
+		end = req.EndTime.AsTime()
 	}
 
 	start := end.Add(-24 * time.Hour)
-	if req.StartTime != nil && req.StartTime.AsTime().UTC().Before(end) {
-		start = req.StartTime.AsTime().UTC()
+	if req.StartTime != nil && req.StartTime.AsTime().Before(end) {
+		start = req.StartTime.AsTime()
 	}
 
 	if end.Sub(start) > 90*24*time.Hour {

--- a/internal/hermes-api/session/page_token.go
+++ b/internal/hermes-api/session/page_token.go
@@ -60,5 +60,5 @@ func ParsePageToken(pToken string) (time.Time, string, error) {
 		return time.Time{}, "", err
 	}
 
-	return pt.BoundTs.AsTime().UTC(), lastUUID.String(), nil
+	return pt.BoundTs.AsTime(), lastUUID.String(), nil
 }

--- a/vendor/github.com/grpc-ecosystem/grpc-gateway/v2/runtime/errors.go
+++ b/vendor/github.com/grpc-ecosystem/grpc-gateway/v2/runtime/errors.go
@@ -38,7 +38,7 @@ func HTTPStatusFromCode(code codes.Code) int {
 	case codes.OK:
 		return http.StatusOK
 	case codes.Canceled:
-		return http.StatusRequestTimeout
+		return 499
 	case codes.Unknown:
 		return http.StatusInternalServerError
 	case codes.InvalidArgument:

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -46,7 +46,7 @@ github.com/google/uuid
 # github.com/gregdel/pushover v1.1.0
 ## explicit; go 1.14
 github.com/gregdel/pushover
-# github.com/grpc-ecosystem/grpc-gateway/v2 v2.12.0
+# github.com/grpc-ecosystem/grpc-gateway/v2 v2.13.0
 ## explicit; go 1.17
 github.com/grpc-ecosystem/grpc-gateway/v2/internal/httprule
 github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2/options
@@ -111,16 +111,16 @@ github.com/skip2/go-qrcode/reedsolomon
 # github.com/smira/go-statsd v1.3.2
 ## explicit; go 1.12
 github.com/smira/go-statsd
-# github.com/stretchr/testify v1.8.0
+# github.com/stretchr/testify v1.8.1
 ## explicit; go 1.13
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/require
-# golang.org/x/crypto v0.0.0-20221012134737-56aed061732a
+# golang.org/x/crypto v0.1.0
 ## explicit; go 1.17
 golang.org/x/crypto/bcrypt
 golang.org/x/crypto/blowfish
 golang.org/x/crypto/pbkdf2
-# golang.org/x/net v0.0.0-20221017152216-f25eb7ecb193
+# golang.org/x/net v0.1.0
 ## explicit; go 1.17
 golang.org/x/net/http/httpguts
 golang.org/x/net/http2
@@ -149,7 +149,7 @@ golang.org/x/text/transform
 golang.org/x/text/unicode/bidi
 golang.org/x/text/unicode/norm
 golang.org/x/text/width
-# google.golang.org/genproto v0.0.0-20221018160656-63c7b68cfc55
+# google.golang.org/genproto v0.0.0-20221027153422-115e99e71e1c
 ## explicit; go 1.19
 google.golang.org/genproto/googleapis/api/annotations
 google.golang.org/genproto/googleapis/api/httpbody

--- a/web/hermes.swagger.json
+++ b/web/hermes.swagger.json
@@ -107,7 +107,10 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/App"
+              "$ref": "#/definitions/App",
+              "required": [
+                "app"
+              ]
             }
           }
         ],
@@ -701,43 +704,57 @@
                   "description": "Identity comment. This should be an opaque identifier known to the consuming application."
                 },
                 "status": {
-                  "$ref": "#/definitions/IdentityStatus"
+                  "$ref": "#/definitions/IdentityStatus",
+                  "description": "Identity status.",
+                  "readOnly": true
                 },
                 "softwareHOTPMethod": {
-                  "$ref": "#/definitions/SoftwareHOTPMethod"
+                  "$ref": "#/definitions/SoftwareHOTPMethod",
+                  "description": "Software HOTP method configuration."
                 },
                 "softwareTOTPMethod": {
-                  "$ref": "#/definitions/SoftwareTOTPMethod"
+                  "$ref": "#/definitions/SoftwareTOTPMethod",
+                  "description": "Software TOTP method configuration."
                 },
                 "googleAuthHOTPMethod": {
-                  "$ref": "#/definitions/GoogleAuthHOTPMethod"
+                  "$ref": "#/definitions/GoogleAuthHOTPMethod",
+                  "description": "Google Authenticator HOTP method configuration."
                 },
                 "googleAuthTOTPMethod": {
-                  "$ref": "#/definitions/GoogleAuthTOTPMethod"
+                  "$ref": "#/definitions/GoogleAuthTOTPMethod",
+                  "description": "Google Authenticator TOTP method configuration."
                 },
                 "appleiOSTOTPMethod": {
-                  "$ref": "#/definitions/AppleiOSTOTPMethod"
+                  "$ref": "#/definitions/AppleiOSTOTPMethod",
+                  "description": "Apple iOS TOTP method configuration."
                 },
                 "hardwareHOTPMethod": {
-                  "$ref": "#/definitions/HardwareHOTPMethod"
+                  "$ref": "#/definitions/HardwareHOTPMethod",
+                  "description": "Hardware HOTP method configuration."
                 },
                 "hardwareTOTPMethod": {
-                  "$ref": "#/definitions/HardwareTOTPMethod"
+                  "$ref": "#/definitions/HardwareTOTPMethod",
+                  "description": "Hardware TOTP method configuration."
                 },
                 "smsMethod": {
-                  "$ref": "#/definitions/SMSMethod"
+                  "$ref": "#/definitions/SMSMethod",
+                  "description": "SMS method configuration."
                 },
                 "pushoverMethod": {
-                  "$ref": "#/definitions/PushoverMethod"
+                  "$ref": "#/definitions/PushoverMethod",
+                  "description": "Pushover method configuration."
                 },
                 "emailMethod": {
-                  "$ref": "#/definitions/EmailMethod"
+                  "$ref": "#/definitions/EmailMethod",
+                  "description": "Email method configuration."
                 },
                 "backupCodesMethod": {
-                  "$ref": "#/definitions/BackupsCodesMethod"
+                  "$ref": "#/definitions/BackupsCodesMethod",
+                  "description": "Backups codes method configuration."
                 },
                 "securityQuestionsMethod": {
-                  "$ref": "#/definitions/SecurityQuestionsMethod"
+                  "$ref": "#/definitions/SecurityQuestionsMethod",
+                  "description": "Security questions method configuration."
                 },
                 "createdAt": {
                   "type": "string",
@@ -987,7 +1004,10 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/Org"
+              "$ref": "#/definitions/Org",
+              "required": [
+                "org"
+              ]
             }
           }
         ],
@@ -1102,10 +1122,13 @@
                   "description": "Organization name."
                 },
                 "status": {
-                  "$ref": "#/definitions/api.Status"
+                  "$ref": "#/definitions/api.Status",
+                  "description": "Organization status."
                 },
                 "plan": {
-                  "$ref": "#/definitions/Plan"
+                  "$ref": "#/definitions/Plan",
+                  "description": "Organization plan.",
+                  "readOnly": true
                 },
                 "createdAt": {
                   "type": "string",
@@ -1173,10 +1196,13 @@
                   "description": "Organization name."
                 },
                 "status": {
-                  "$ref": "#/definitions/api.Status"
+                  "$ref": "#/definitions/api.Status",
+                  "description": "Organization status."
                 },
                 "plan": {
-                  "$ref": "#/definitions/Plan"
+                  "$ref": "#/definitions/Plan",
+                  "description": "Organization plan.",
+                  "readOnly": true
                 },
                 "createdAt": {
                   "type": "string",
@@ -1276,7 +1302,10 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/Key"
+              "$ref": "#/definitions/Key",
+              "required": [
+                "key"
+              ]
             }
           }
         ],
@@ -1426,7 +1455,10 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/User"
+              "$ref": "#/definitions/User",
+              "required": [
+                "user"
+              ]
             }
           }
         ],
@@ -1601,10 +1633,12 @@
                   "description": "User email."
                 },
                 "role": {
-                  "$ref": "#/definitions/Role"
+                  "$ref": "#/definitions/Role",
+                  "description": "User role."
                 },
                 "status": {
-                  "$ref": "#/definitions/api.Status"
+                  "$ref": "#/definitions/api.Status",
+                  "description": "User status."
                 },
                 "createdAt": {
                   "type": "string",
@@ -1681,10 +1715,12 @@
                   "description": "User email."
                 },
                 "role": {
-                  "$ref": "#/definitions/Role"
+                  "$ref": "#/definitions/Role",
+                  "description": "User role."
                 },
                 "status": {
-                  "$ref": "#/definitions/api.Status"
+                  "$ref": "#/definitions/api.Status",
+                  "description": "User status."
                 },
                 "createdAt": {
                   "type": "string",
@@ -1802,7 +1838,8 @@
       "type": "object",
       "properties": {
         "identity": {
-          "$ref": "#/definitions/Identity"
+          "$ref": "#/definitions/Identity",
+          "description": "Identity message created."
         },
         "secret": {
           "type": "string",
@@ -1827,7 +1864,8 @@
       "type": "object",
       "properties": {
         "key": {
-          "$ref": "#/definitions/Key"
+          "$ref": "#/definitions/Key",
+          "description": "Key message created."
         },
         "token": {
           "type": "string",
@@ -1862,7 +1900,8 @@
           "description": "Identity ID (UUID)."
         },
         "status": {
-          "$ref": "#/definitions/EventStatus"
+          "$ref": "#/definitions/EventStatus",
+          "description": "Event status."
         },
         "error": {
           "type": "string",
@@ -1921,7 +1960,8 @@
       "type": "object",
       "properties": {
         "hash": {
-          "$ref": "#/definitions/Hash"
+          "$ref": "#/definitions/Hash",
+          "description": "Hardware HOTP hash function. Defaults to SHA512 if not specified."
         },
         "digits": {
           "type": "integer",
@@ -1945,7 +1985,8 @@
       "type": "object",
       "properties": {
         "hash": {
-          "$ref": "#/definitions/Hash"
+          "$ref": "#/definitions/Hash",
+          "description": "Hardware TOTP hash function. Defaults to SHA512 if not specified."
         },
         "digits": {
           "type": "integer",
@@ -1993,43 +2034,57 @@
           "description": "Identity comment. This should be an opaque identifier known to the consuming application."
         },
         "status": {
-          "$ref": "#/definitions/IdentityStatus"
+          "$ref": "#/definitions/IdentityStatus",
+          "description": "Identity status.",
+          "readOnly": true
         },
         "softwareHOTPMethod": {
-          "$ref": "#/definitions/SoftwareHOTPMethod"
+          "$ref": "#/definitions/SoftwareHOTPMethod",
+          "description": "Software HOTP method configuration."
         },
         "softwareTOTPMethod": {
-          "$ref": "#/definitions/SoftwareTOTPMethod"
+          "$ref": "#/definitions/SoftwareTOTPMethod",
+          "description": "Software TOTP method configuration."
         },
         "googleAuthHOTPMethod": {
-          "$ref": "#/definitions/GoogleAuthHOTPMethod"
+          "$ref": "#/definitions/GoogleAuthHOTPMethod",
+          "description": "Google Authenticator HOTP method configuration."
         },
         "googleAuthTOTPMethod": {
-          "$ref": "#/definitions/GoogleAuthTOTPMethod"
+          "$ref": "#/definitions/GoogleAuthTOTPMethod",
+          "description": "Google Authenticator TOTP method configuration."
         },
         "appleiOSTOTPMethod": {
-          "$ref": "#/definitions/AppleiOSTOTPMethod"
+          "$ref": "#/definitions/AppleiOSTOTPMethod",
+          "description": "Apple iOS TOTP method configuration."
         },
         "hardwareHOTPMethod": {
-          "$ref": "#/definitions/HardwareHOTPMethod"
+          "$ref": "#/definitions/HardwareHOTPMethod",
+          "description": "Hardware HOTP method configuration."
         },
         "hardwareTOTPMethod": {
-          "$ref": "#/definitions/HardwareTOTPMethod"
+          "$ref": "#/definitions/HardwareTOTPMethod",
+          "description": "Hardware TOTP method configuration."
         },
         "smsMethod": {
-          "$ref": "#/definitions/SMSMethod"
+          "$ref": "#/definitions/SMSMethod",
+          "description": "SMS method configuration."
         },
         "pushoverMethod": {
-          "$ref": "#/definitions/PushoverMethod"
+          "$ref": "#/definitions/PushoverMethod",
+          "description": "Pushover method configuration."
         },
         "emailMethod": {
-          "$ref": "#/definitions/EmailMethod"
+          "$ref": "#/definitions/EmailMethod",
+          "description": "Email method configuration."
         },
         "backupCodesMethod": {
-          "$ref": "#/definitions/BackupsCodesMethod"
+          "$ref": "#/definitions/BackupsCodesMethod",
+          "description": "Backups codes method configuration."
         },
         "securityQuestionsMethod": {
-          "$ref": "#/definitions/SecurityQuestionsMethod"
+          "$ref": "#/definitions/SecurityQuestionsMethod",
+          "description": "Security questions method configuration."
         },
         "createdAt": {
           "type": "string",
@@ -2076,7 +2131,8 @@
           "description": "Key name."
         },
         "role": {
-          "$ref": "#/definitions/Role"
+          "$ref": "#/definitions/Role",
+          "description": "Key role."
         },
         "createdAt": {
           "type": "string",
@@ -2278,10 +2334,13 @@
           "description": "Organization name."
         },
         "status": {
-          "$ref": "#/definitions/api.Status"
+          "$ref": "#/definitions/api.Status",
+          "description": "Organization status."
         },
         "plan": {
-          "$ref": "#/definitions/Plan"
+          "$ref": "#/definitions/Plan",
+          "description": "Organization plan.",
+          "readOnly": true
         },
         "createdAt": {
           "type": "string",
@@ -2356,7 +2415,8 @@
       "type": "object",
       "properties": {
         "hash": {
-          "$ref": "#/definitions/Hash"
+          "$ref": "#/definitions/Hash",
+          "description": "Software HOTP hash function. Defaults to SHA512 if not specified."
         },
         "digits": {
           "type": "integer",
@@ -2379,7 +2439,8 @@
       "type": "object",
       "properties": {
         "hash": {
-          "$ref": "#/definitions/Hash"
+          "$ref": "#/definitions/Hash",
+          "description": "Software TOTP hash function. Defaults to SHA512 if not specified."
         },
         "digits": {
           "type": "integer",
@@ -2415,10 +2476,12 @@
           "description": "User email."
         },
         "role": {
-          "$ref": "#/definitions/Role"
+          "$ref": "#/definitions/Role",
+          "description": "User role."
         },
         "status": {
-          "$ref": "#/definitions/api.Status"
+          "$ref": "#/definitions/api.Status",
+          "description": "User status."
         },
         "createdAt": {
           "type": "string",


### PR DESCRIPTION
- Clean up superfluous `.AsTime().UTC()`.
- Sync `vendor/` for updated dependencies.
- All test variations pass.