### PR TITLE
Make API host configurable to silence potential firewall prompts

### DIFF
--- a/build/deploy/hermes/docker-compose.yml
+++ b/build/deploy/hermes/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   hermes-api:
-    image: ghcr.io/ownmfa/hermes:550b037c
+    image: ghcr.io/ownmfa/hermes:efcf4ad3
     command: hermes-api
     restart: on-failure
     depends_on:
@@ -31,7 +31,7 @@ services:
       - "traefik.http.services.hermes-grpc.loadbalancer.server.scheme=h2c"
 
   hermes-notifier:
-    image: ghcr.io/ownmfa/hermes:550b037c
+    image: ghcr.io/ownmfa/hermes:efcf4ad3
     command: hermes-notifier
     restart: on-failure
     environment:

--- a/internal/hermes-api/config/config.go
+++ b/internal/hermes-api/config/config.go
@@ -14,15 +14,16 @@ type Config struct {
 	PgURI     string
 	RedisHost string
 
-	PWTKey      []byte
-	IdentityKey []byte
-
 	NSQPubAddr  string
 	NSQPubTopic string
 
 	SMSKeyID       string
 	SMSKeySecret   string
 	PushoverAPIKey string
+
+	PWTKey      []byte
+	IdentityKey []byte
+	APIHost     string
 }
 
 // New instantiates a service Config, parses the environment, and returns it.
@@ -35,9 +36,6 @@ func New() *Config {
 			"postgres://postgres:postgres@127.0.0.1/hermes_test"),
 		RedisHost: config.String(pref+"REDIS_HOST", "127.0.0.1"),
 
-		PWTKey:      config.ByteSlice(pref + "PWT_KEY"),
-		IdentityKey: config.ByteSlice(pref + "IDENTITY_KEY"),
-
 		NSQPubAddr:  config.String(pref+"NSQ_PUB_ADDR", "127.0.0.1:4150"),
 		NSQPubTopic: config.String(pref+"NSQ_PUB_TOPIC", "NotifierIn"),
 
@@ -45,5 +43,9 @@ func New() *Config {
 			"SKc8b34a092fe8790061c58b3fb3db752f"),
 		SMSKeySecret:   config.String(pref+"SMS_KEY_SECRET", ""),
 		PushoverAPIKey: config.String(pref+"PUSHOVER_API_KEY", ""),
+
+		PWTKey:      config.ByteSlice(pref + "PWT_KEY"),
+		IdentityKey: config.ByteSlice(pref + "IDENTITY_KEY"),
+		APIHost:     config.String(pref+"API_HOST", ""),
 	}
 }

--- a/internal/hermes-api/test/main_test.go
+++ b/internal/hermes-api/test/main_test.go
@@ -68,13 +68,14 @@ func TestMain(m *testing.M) {
 	cfg.PgURI = testConfig.PgURI
 	cfg.RedisHost = testConfig.RedisHost
 
-	cfg.PWTKey = key
-	cfg.IdentityKey = key
-
 	cfg.NSQPubAddr = testConfig.NSQPubAddr
 	cfg.NSQPubTopic += "-test-" + random.String(10)
 	globalPubTopic = cfg.NSQPubTopic
 	log.Printf("TestMain cfg.NSQPubTopic: %v", cfg.NSQPubTopic)
+
+	cfg.PWTKey = key
+	cfg.IdentityKey = key
+	cfg.APIHost = testConfig.APIHost
 
 	// Set up API.
 	a, err := iapi.New(cfg)

--- a/pkg/test/config/config.go
+++ b/pkg/test/config/config.go
@@ -13,6 +13,8 @@ type Config struct {
 
 	NSQPubAddr     string
 	NSQLookupAddrs []string
+
+	APIHost string
 }
 
 // New instantiates a test Config, parses the environment, and returns it.
@@ -25,5 +27,7 @@ func New() *Config {
 		NSQPubAddr: config.String(pref+"NSQ_PUB_ADDR", "127.0.0.1:4150"),
 		NSQLookupAddrs: config.StringSlice(pref+"NSQ_LOOKUP_ADDRS",
 			[]string{"127.0.0.1:4161"}),
+
+		APIHost: config.String(pref+"API_HOST", "127.0.0.1"),
 	}
 }


### PR DESCRIPTION
- Update config, api, integration tests, and `pkg/test/config`.
- All test variations pass.