### PR TITLE
Remove GitHub CI cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,20 +36,13 @@ jobs:
         image: redis:7-alpine
     steps:
       - name: Deps
-        # Add packages needed to support checkout, cache, builds, and tests
+        # Add packages needed to support checkout, builds, and tests
         run: |
           apk update && apk upgrade
-          apk add --no-cache git tar make
+          apk add --no-cache git make
           go env
       - name: Clone
         uses: actions/checkout@v4
-      - name: Cache
-        uses: actions/cache@v4
-        with:
-          # Cache modules only, not build
-          path: /go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('Makefile') }}
-          restore-keys: ${{ runner.os }}-go-
       - name: Build_and_Test
         run: make test
       - name: Push

--- a/build/deploy/hermes/docker-compose.yml
+++ b/build/deploy/hermes/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   hermes-api:
-    image: ghcr.io/ownmfa/hermes:c68a15df
+    image: ghcr.io/ownmfa/hermes:fd691543
     command: hermes-api
     restart: on-failure
     depends_on:
@@ -35,7 +35,7 @@ services:
       - "traefik.http.services.hermes-grpc.loadbalancer.server.scheme=h2c"
 
   hermes-notifier:
-    image: ghcr.io/ownmfa/hermes:c68a15df
+    image: ghcr.io/ownmfa/hermes:fd691543
     command: hermes-notifier
     restart: on-failure
     environment:


### PR DESCRIPTION
- It is no faster than the Go package proxy and adds complexity.
- All test variations pass.